### PR TITLE
feat: implement build_uprn_lsoa

### DIFF
--- a/src/houseprices/spatial.py
+++ b/src/houseprices/spatial.py
@@ -2,6 +2,7 @@
 
 import pathlib
 
+import duckdb
 import pandas as pd
 
 
@@ -14,4 +15,21 @@ def build_uprn_lsoa(
     Returns a DataFrame with columns: UPRN, LSOA21CD, LSOA21NM.
     Only UPRNs that fall within a boundary polygon are included.
     """
-    raise NotImplementedError
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+
+    uprn = str(uprn_path)
+    boundary = str(boundary_path)
+
+    return con.execute(f"""
+        SELECT
+            u.UPRN,
+            l.LSOA21CD,
+            l.LSOA21NM
+        FROM read_csv('{uprn}') AS u
+        JOIN ST_Read('{boundary}') AS l
+          ON ST_Within(
+              ST_Point(u.X_COORDINATE, u.Y_COORDINATE),
+              l.geom
+          )
+    """).df()


### PR DESCRIPTION
## Summary

- Implements `build_uprn_lsoa` in `spatial.py` using DuckDB's spatial extension
- Loads OS Open UPRN CSV and LSOA GeoJSON, runs `ST_Within(ST_Point(X, Y), geom)` point-in-polygon join
- Both datasets use BNG EPSG:27700 — no CRS reprojection needed
- UPRNs outside all boundary polygons are excluded (inner join)
- Full TDD cycle complete: red phase was #4, this is green + type-check + lint

## Test plan

- [x] `uv run pytest --cov` — 15 tests, 100% coverage
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)