### PR TITLE
docs: correct UBDC field names and add ONS boundary research

### DIFF
--- a/research/ons-boundary-format.md
+++ b/research/ons-boundary-format.md
@@ -1,0 +1,137 @@
+# ONS LSOA Boundary File Format
+
+Research into which format of the ONS LSOA 2021 boundary file works best
+with DuckDB's spatial extension, and what CRS considerations apply.
+
+---
+
+## Available formats
+
+The ONS Open Geography Portal[^geoportal] publishes LSOA 2021 boundaries in
+multiple formats:
+
+| Format | Extension | Notes |
+|---|---|---|
+| Shapefile | `.shp` + sidecar files | Legacy format; 2 GB file size limit; multiple files |
+| GeoJSON | `.geojson` | Single file; human-readable; large on disk |
+| GeoPackage | `.gpkg` | Single binary file; spatially indexed; no size limit |
+
+GeoParquet is not offered directly by the ONS geoportal (as of March 2026).
+
+**Recommended format: GeoPackage (`.gpkg`).**
+
+DuckDB's spatial extension reads GeoPackage via `ST_Read` with no additional
+configuration. The single-file format is simpler to manage than Shapefile's
+sidecar files, and its spatial index makes point-in-polygon queries faster
+than scanning an unindexed GeoJSON.
+
+---
+
+## Generalised vs full resolution
+
+The ONS publishes several clipping/generalisation variants:
+
+| Code | Description | Use case |
+|---|---|---|
+| BFE | Full Extent | Includes coastal/estuarine areas; largest file |
+| BFC | Full Clipped | Clipped to coastline; large |
+| BGC | Generalised Clipped | 20 m generalisation; **recommended for joins** |
+| BSC | Super Generalised Clipped | 200 m generalisation; for small-scale maps only |
+| BUC | Ultra Generalised Clipped | 500 m generalisation; for national overview maps |
+
+For point-in-polygon joins, the **BGC (Generalised Clipped, 20 m)** variant
+is the right choice. Full-resolution boundaries add no accuracy benefit for
+assigning a point to its containing polygon, and the smaller file size speeds
+up the DuckDB spatial join considerably.
+
+The V4 BSC dataset URL found during research:
+`https://geoportal.statistics.gov.uk/datasets/ons::lower-layer-super-output-areas-december-2021-boundaries-ew-bsc-v4-2/about`
+
+Search for the BGC variant on the portal — URL pattern will be similar with
+`bgc` in the dataset slug.
+
+---
+
+## CRS
+
+ONS boundary files use **BNG (British National Grid, EPSG:27700)** as the
+standard CRS for England and Wales datasets. A WGS84 (EPSG:4326) variant is
+sometimes published separately (labelled "WGS84" in the dataset title).
+
+**Use the BNG variant.** OS Open UPRN coordinates are also in BNG
+(EPSG:27700), so no reprojection is needed for the spatial join:
+
+```sql
+-- Both UPRN coordinates and boundary polygons are in EPSG:27700
+-- ST_Point(easting, northing) is directly comparable to l.geom
+ST_Within(
+    ST_Point(u.X_COORDINATE, u.Y_COORDINATE),
+    l.geom
+)
+```
+
+If only the WGS84 variant is available, reproject the UPRN point:
+
+```sql
+-- Reproject BNG point to WGS84 before comparing to WGS84 boundary
+ST_Within(
+    ST_Transform(ST_Point(u.X_COORDINATE, u.Y_COORDINATE), 'EPSG:27700', 'EPSG:4326'),
+    l.geom
+)
+```
+
+---
+
+## Column names
+
+Confirmed from dataset documentation and consistent with our fixture GeoJSON:
+
+| Column | Type | Description |
+|---|---|---|
+| `LSOA21CD` | VARCHAR | LSOA 2021 code (e.g. `E01000001`) |
+| `LSOA21NM` | VARCHAR | LSOA 2021 name (e.g. `City of London 001A`) |
+| `LSOA21NMW` | VARCHAR | Welsh name (Wales only; NULL for England) |
+| `geom` | GEOMETRY | Polygon geometry (DuckDB ST_Read column name) |
+
+These match the column names already used in `tests/fixtures/lsoa_sample.geojson`
+and `src/houseprices/spatial.py`. No changes needed to the join query.
+
+---
+
+## Download instructions
+
+1. Go to: `https://geoportal.statistics.gov.uk/`
+2. Search for: `LSOA December 2021 Boundaries BGC`
+3. Select the England and Wales (EW) dataset
+4. Click "Download" → choose GeoPackage
+5. Save as `data/lsoa_boundaries.gpkg`
+
+The pipeline's `download_data()` function should automate this. The ONS
+geoportal provides a direct download API URL — confirm the current URL when
+implementing the download step, as the geoportal occasionally changes slugs.
+
+---
+
+## DuckDB ST_Read usage
+
+```python
+import duckdb
+
+con = duckdb.connect()
+con.execute("INSTALL spatial; LOAD spatial;")
+
+# Works with both GeoPackage and GeoJSON
+result = con.execute("""
+    SELECT LSOA21CD, LSOA21NM, geom
+    FROM ST_Read('data/lsoa_boundaries.gpkg')
+    LIMIT 5
+""").df()
+```
+
+---
+
+## References
+
+[^geoportal]: ONS Open Geography Portal. <https://geoportal.statistics.gov.uk/>
+
+[^lsoa-bsc]: ONS, "Lower layer Super Output Areas (December 2021) Boundaries EW BSC (V4)". <https://geoportal.statistics.gov.uk/datasets/ons::lower-layer-super-output-areas-december-2021-boundaries-ew-bsc-v4-2/about>

--- a/research/ubdc-ppd-uprn-lookup.md
+++ b/research/ubdc-ppd-uprn-lookup.md
@@ -14,19 +14,53 @@ A lookup table with three fields:
 
 | Field | Description |
 |---|---|
-| `lmk` | PPD unique transaction identifier |
-| `UPRN` | Unique Property Reference Number |
-| `USRN` | Unique Street Reference Number |
+| `transactionid` | PPD unique transaction identifier — matches `transaction_unique_identifier` in HMLR PPD CSV |
+| `uprn` | Unique Property Reference Number |
+| `method` | Which of the 142 matching rules produced the link (e.g. `"method1"`) |
 
 - **Match rate**: 96% of PPD records successfully linked to a UPRN[^ubdc]
 - **Coverage**: January 1995 to January 2022[^ubdc]
 - **Licence**: Open Government Licence[^ubdc]
-- **Format**: zip / xlsx
+- **Format**: zip / CSV (confirm on download — earlier versions were xlsx)
 - **Last updated**: 10 March 2026[^ubdc]
 
 The linkage was produced using a 142-rule rules-based methodology[^github] —
 the same methodology as the companion EPC linkage, but applied to PPD, which
 the authors describe as "easier than Domestic EPCs."[^github]
+
+---
+
+## Field name correction (March 2026)
+
+**Earlier versions of this document (and PLAN.md) used `lmk` as the PPD
+identifier field name. This was incorrect.**
+
+The correct field name is `transactionid`, confirmed by inspecting the UBDC
+linkage source code (`lrppd_os_final.R`)[^rscript]. Key evidence:
+
+```r
+# From lrppd_os_final.R — the function that filters already-matched records:
+matchleft <- function(x, y) {
+  next0 <- x[!(x$transactionid %in% y$transactionid), ]
+  return(next0)
+}
+
+# The final output column list written to file:
+needlistf <- c("transactionid", "uprn", "method")
+```
+
+The variable `tran` (loaded from HMLR PPD) is also keyed on `transactionid`
+throughout the script. This field corresponds to HMLR's
+`transaction_unique_identifier` in the PPD CSV — a curly-braced UUID string,
+e.g. `{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}`.
+
+The `lmk` and `lmk_key` names appear in the companion EPC linkage and in some
+secondary documentation, which is likely the source of the earlier confusion.
+The PPD linkage consistently uses `transactionid`.
+
+**Action on download**: confirm the column is named `transactionid` in the
+published CSV. If the March 2026 release has renamed it, update the join code
+in `pipeline.py` accordingly.
 
 ---
 
@@ -39,10 +73,15 @@ This resolves the key unknown in our join strategy. We no longer need to:
 The Tier 1 join becomes:
 
 ```
-PPD lmk → UBDC lookup → UPRN
-EPC UPRN (from DLUHC backfill)
-→ direct UPRN join
+PPD transaction_unique_identifier
+  → UBDC lookup (transactionid) → UPRN
+  → EPC UPRN (from DLUHC backfill)
+  → direct UPRN join
 ```
+
+The `method` column in the lookup records which matching rule produced each
+link. This could be used to flag lower-confidence matches (high rule numbers
+tend to be fuzzier), but for our purposes we treat all UBDC matches as Tier 1.
 
 ### Estimated coverage
 
@@ -74,15 +113,6 @@ Note: the dataset was updated 10 March 2026 and may now extend beyond January
 
 ---
 
-## `lmk` field mapping
-
-The lookup uses `lmk` as the PPD identifier. Confirm this maps to the
-`transaction_id` field in the PPD CSV before joining. In Land Registry
-documentation this field is sometimes called `transaction_unique_identifier`
-or `lmk_key` — verify the exact column name on download.
-
----
-
 ## Licence note
 
 OGL — compatible with our use. No commercial restriction (unlike the GitHub
@@ -98,5 +128,7 @@ repo[^github] which is CC-BY-NC). Cite as:
 [^ubdc]: Urban Big Data Centre, "Price paid data to UPRN lookup" (updated 10 March 2026). <https://data.ubdc.ac.uk/dataset/a999fd05-e7fe-4243-ab9a-95ce98132956>
 
 [^github]: Urban Big Data Centre, `os_epc_ppd_linkage` GitHub repository. <https://github.com/urbanbigdatacentre/os_epc_ppd_linkage>
+
+[^rscript]: Bin Chi (UBDC), `lrppd_os_final.R` — PPD to UPRN linkage source code. <https://github.com/urbanbigdatacentre/os_epc_ppd_linkage/blob/main/PPD/lrppd_os_final.R>
 
 [^boswarva]: Owen Boswarva, "Allocating UPRNs to Energy Performance Certificates" (early 2022). <https://www.owenboswarva.com/blog/post-hou3.htm>


### PR DESCRIPTION
## Summary

Two research document updates based on inspecting the UBDC source code and ONS geoportal.

### UBDC field name correction

The PPD identifier field in the UBDC lookup is `transactionid`, **not `lmk`** as previously documented. Confirmed from `lrppd_os_final.R`:

```r
needlistf <- c("transactionid", "uprn", "method")
```

`transactionid` maps directly to HMLR's `transaction_unique_identifier` ({UUID} format). The `lmk`/`lmk_key` naming comes from the companion EPC linkage — not the PPD output. Added a prominent correction notice with the R code evidence.

### ONS boundary format

New research note covering:
- GeoPackage recommended over GeoJSON/Shapefile (indexed, single file, DuckDB-native)
- BGC (20 m generalised) variant is right for point-in-polygon joins
- CRS is BNG EPSG:27700 — matches OS Open UPRN, no reprojection needed
- Confirmed `LSOA21CD` / `LSOA21NM` column names match existing fixtures

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)