### PR TITLE
feat(download): add streaming download functions for all data sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "mypy>=1.10.0",
     "ruff>=0.5.0",
     "pandas-stubs>=2.2.0",
+    "types-requests>=2.32.0",
 ]
 
 [build-system]

--- a/src/houseprices/download.py
+++ b/src/houseprices/download.py
@@ -1,0 +1,127 @@
+"""Download raw data files from upstream sources.
+
+URL constants are declared at module level so they can be inspected and
+overridden without touching the download functions.  Fill in the TODO
+entries once you have confirmed the direct-download URLs.
+"""
+
+import base64
+import pathlib
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Source URLs
+# ---------------------------------------------------------------------------
+
+# HM Land Registry Price Paid Data — complete CSV (OGL).
+# Updated monthly; currently includes sales through January 2026.
+PPD_URL = (
+    "http://prod.publicdata.landregistry.gov.uk"
+    ".s3-website-eu-west-1.amazonaws.com/pp-complete.csv"
+)
+
+# EPC bulk download — ZIP of all domestic certificates (OGL).
+# Requires free registration at https://epc.opendatacommunities.org/
+# Authenticates via HTTP Basic Auth: email address + API key.
+# TODO: confirm the exact bulk-download endpoint URL after registration.
+EPC_BULK_URL: str = ""
+
+# UBDC PPD → UPRN lookup — ZIP containing CSV (OGL).
+# Dataset page: https://data.ubdc.ac.uk/dataset/a999fd05-e7fe-4243-ab9a-95ce98132956
+# TODO: confirm the direct-download URL from the dataset page.
+UBDC_URL: str = ""
+
+# OS Open UPRN — ZIP of all UPRNs with BNG coordinates (OGL).
+# Requires a free API key from https://osdatahub.os.uk/
+# TODO: confirm the download endpoint; key is appended as ?key={api_key}.
+OS_OPEN_UPRN_URL: str = ""
+
+# ONS LSOA December 2021 Boundaries EW BGC — GeoPackage, BNG (OGL).
+# See research/ons-boundary-format.md for format and CRS guidance.
+# TODO: confirm the direct-download URL from https://geoportal.statistics.gov.uk/
+LSOA_BGC_URL: str = ""
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_CHUNK_SIZE = 1024 * 1024  # 1 MB
+
+
+def _stream_to_file(
+    url: str,
+    dest: pathlib.Path,
+    *,
+    headers: dict[str, str] | None = None,
+) -> pathlib.Path:
+    """Stream *url* to *dest*, skipping if the file already exists."""
+    if dest.exists():
+        print(f"  [skip] {dest.name} (already downloaded)")
+        return dest
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    print(f"  [get]  {url} → {dest}")
+
+    response = requests.get(url, headers=headers or {}, stream=True, timeout=120)
+    response.raise_for_status()
+
+    with dest.open("wb") as fh:
+        for chunk in response.iter_content(chunk_size=_CHUNK_SIZE):
+            fh.write(chunk)
+
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Public download functions
+# ---------------------------------------------------------------------------
+
+
+def download_ppd(data_dir: pathlib.Path) -> pathlib.Path:
+    """Download the complete Price Paid Data CSV."""
+    return _stream_to_file(PPD_URL, data_dir / "pp-complete.csv")
+
+
+def download_epc(
+    data_dir: pathlib.Path,
+    *,
+    email: str,
+    api_key: str,
+) -> pathlib.Path:
+    """Download the EPC bulk ZIP.
+
+    Credentials are from the free epc.opendatacommunities.org registration.
+    Authenticates via HTTP Basic Auth (email address + API key).
+    """
+    token = base64.b64encode(f"{email}:{api_key}".encode()).decode()
+    return _stream_to_file(
+        EPC_BULK_URL,
+        data_dir / "epc-domestic-all.zip",
+        headers={"Authorization": f"Basic {token}"},
+    )
+
+
+def download_ubdc(data_dir: pathlib.Path) -> pathlib.Path:
+    """Download the UBDC PPD → UPRN lookup ZIP."""
+    return _stream_to_file(UBDC_URL, data_dir / "ppd-uprn-lookup.zip")
+
+
+def download_os_open_uprn(
+    data_dir: pathlib.Path,
+    *,
+    api_key: str,
+) -> pathlib.Path:
+    """Download OS Open UPRN ZIP.
+
+    Requires a free API key from https://osdatahub.os.uk/
+    The key is appended as a query parameter — confirm the exact mechanism
+    against the OS Data Hub download documentation before running.
+    """
+    url = f"{OS_OPEN_UPRN_URL}?key={api_key}"
+    return _stream_to_file(url, data_dir / "os-open-uprn.zip")
+
+
+def download_lsoa_boundaries(data_dir: pathlib.Path) -> pathlib.Path:
+    """Download ONS LSOA December 2021 BGC boundaries as a GeoPackage."""
+    return _stream_to_file(LSOA_BGC_URL, data_dir / "lsoa_boundaries.gpkg")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,169 @@
+"""Tests for download.py: skip-if-exists, streaming, and auth headers."""
+
+from __future__ import annotations
+
+import base64
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import houseprices.download as dl
+
+
+def _mock_response(chunks: list[bytes] | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.iter_content.return_value = iter(chunks or [b"data"])
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _stream_to_file internals
+# ---------------------------------------------------------------------------
+
+
+def test_skips_download_if_file_exists(tmp_path: pathlib.Path) -> None:
+    dest = tmp_path / "file.csv"
+    dest.write_bytes(b"existing")
+    with patch("houseprices.download.requests.get") as mock_get:
+        result = dl._stream_to_file("http://example.com/f", dest)
+    mock_get.assert_not_called()
+    assert result == dest
+
+
+def test_writes_response_chunks(tmp_path: pathlib.Path) -> None:
+    dest = tmp_path / "file.csv"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response([b"hello ", b"world"]),
+    ):
+        dl._stream_to_file("http://example.com/f", dest)
+    assert dest.read_bytes() == b"hello world"
+
+
+def test_raises_on_http_error(tmp_path: pathlib.Path) -> None:
+    dest = tmp_path / "file.csv"
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = Exception("404 Not Found")
+    with (
+        patch("houseprices.download.requests.get", return_value=resp),
+        pytest.raises(Exception, match="404"),
+    ):
+        dl._stream_to_file("http://example.com/f", dest)
+
+
+def test_creates_parent_directories(tmp_path: pathlib.Path) -> None:
+    dest = tmp_path / "nested" / "dir" / "file.csv"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ):
+        dl._stream_to_file("http://example.com/f", dest)
+    assert dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# download_ppd
+# ---------------------------------------------------------------------------
+
+
+def test_download_ppd_uses_ppd_url(tmp_path: pathlib.Path) -> None:
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ) as mock_get:
+        dl.download_ppd(tmp_path)
+    assert mock_get.call_args.args[0] == dl.PPD_URL
+
+
+def test_download_ppd_saves_as_csv(tmp_path: pathlib.Path) -> None:
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ):
+        result = dl.download_ppd(tmp_path)
+    assert result.name == "pp-complete.csv"
+
+
+# ---------------------------------------------------------------------------
+# download_epc
+# ---------------------------------------------------------------------------
+
+
+def test_download_epc_uses_basic_auth(tmp_path: pathlib.Path) -> None:
+    dl.EPC_BULK_URL = "http://example.com/epc.zip"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ) as mock_get:
+        dl.download_epc(tmp_path, email="user@example.com", api_key="s3cr3t")
+    headers = mock_get.call_args.kwargs["headers"]
+    expected = base64.b64encode(b"user@example.com:s3cr3t").decode()
+    assert headers["Authorization"] == f"Basic {expected}"
+
+
+def test_download_epc_saves_as_zip(tmp_path: pathlib.Path) -> None:
+    dl.EPC_BULK_URL = "http://example.com/epc.zip"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ):
+        result = dl.download_epc(tmp_path, email="u@e.com", api_key="k")
+    assert result.name == "epc-domestic-all.zip"
+
+
+# ---------------------------------------------------------------------------
+# download_ubdc
+# ---------------------------------------------------------------------------
+
+
+def test_download_ubdc_saves_as_zip(tmp_path: pathlib.Path) -> None:
+    dl.UBDC_URL = "http://example.com/ubdc.zip"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ):
+        result = dl.download_ubdc(tmp_path)
+    assert result.name == "ppd-uprn-lookup.zip"
+
+
+# ---------------------------------------------------------------------------
+# download_os_open_uprn
+# ---------------------------------------------------------------------------
+
+
+def test_download_os_open_uprn_passes_api_key(tmp_path: pathlib.Path) -> None:
+    dl.OS_OPEN_UPRN_URL = "http://example.com/uprn"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ) as mock_get:
+        dl.download_os_open_uprn(tmp_path, api_key="mykey")
+    called_url: str = mock_get.call_args.args[0]
+    assert "mykey" in called_url
+
+
+def test_download_os_open_uprn_saves_as_zip(tmp_path: pathlib.Path) -> None:
+    dl.OS_OPEN_UPRN_URL = "http://example.com/uprn"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ):
+        result = dl.download_os_open_uprn(tmp_path, api_key="k")
+    assert result.name == "os-open-uprn.zip"
+
+
+# ---------------------------------------------------------------------------
+# download_lsoa_boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_download_lsoa_saves_as_gpkg(tmp_path: pathlib.Path) -> None:
+    dl.LSOA_BGC_URL = "http://example.com/lsoa.gpkg"
+    with patch(
+        "houseprices.download.requests.get",
+        return_value=_mock_response(),
+    ):
+        result = dl.download_lsoa_boundaries(tmp_path)
+    assert result.name == "lsoa_boundaries.gpkg"


### PR DESCRIPTION
## Summary

- New `src/houseprices/download.py` with one function per data source
- URL constants in a block at the top of the module — no URLs hardcoded inside functions
- `PPD_URL` confirmed and populated; EPC, UBDC, OS Open UPRN, and ONS LSOA have empty-string `TODO` placeholders with links to registration pages and notes on auth mechanism
- Sources requiring credentials take them as keyword-only args (`email`/`api_key`) — not from env yet
- All functions skip download if the destination file already exists
- Adds `types-requests` to dev deps for mypy strict

## Auth mechanisms documented

| Source | Auth |
|---|---|
| PPD | None (public S3) |
| EPC | HTTP Basic Auth (email + API key from free registration) |
| UBDC | None (OGL public) |
| OS Open UPRN | `?key=` query param (OS Data Hub API key) |
| ONS LSOA | None (OGL public) |

## Test plan

- [x] 47 tests pass, 100% coverage
- [x] ruff check, ruff format, mypy strict all clean
- [x] skip-if-exists tested, streaming chunks tested, Basic Auth header tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)