### PR TITLE
feat(pipeline): replace aggregate_by_postcode_district with aggregate_by_geography

### DIFF
--- a/src/houseprices/pipeline.py
+++ b/src/houseprices/pipeline.py
@@ -2,8 +2,23 @@
 
 import pathlib
 import re
+from enum import Enum
 
 import pandas as pd
+
+
+class Geography(Enum):
+    """Contiguous geographies supported for price-per-sqm aggregation.
+
+    The enum value is the output column name in the aggregated DataFrame.
+    For POSTCODE_DISTRICT the column is derived from the ``postcode`` field.
+    For all other geographies the column must already be present in the
+    matched DataFrame (populated by the spatial join step).
+    """
+
+    POSTCODE_DISTRICT = "postcode_district"
+    LSOA = "LSOA21CD"
+
 
 _ABBREVIATIONS: list[tuple[str, str]] = [
     (r"\bAPARTMENT\b", "FLAT"),
@@ -135,23 +150,32 @@ def match_report(matched: pd.DataFrame, total_ppd: int) -> dict[str, int | float
     }
 
 
-def aggregate_by_postcode_district(
+def aggregate_by_geography(
     matched: pd.DataFrame,
+    geography: Geography,
     min_sales: int = 10,
 ) -> pd.DataFrame:
-    """Aggregate matched records to price per m² by postcode district.
+    """Aggregate matched records to price per m² by the given geography.
 
-    Postcode district is the outward code: last three characters (the inward
-    code) are stripped, e.g. "SW1A 1AA" → "SW1A", "N1 1AA" → "N1".
+    For ``Geography.POSTCODE_DISTRICT`` the district is derived from the
+    ``postcode`` column (last three characters stripped).  For all other
+    geographies the column named by ``geography.value`` must already be
+    present in *matched* — it is populated by the spatial join step.
 
-    Districts with fewer than min_sales transactions are excluded.
+    Rows without a value for the target geography are excluded.
+    Geographies with fewer than *min_sales* transactions are excluded.
     Result is sorted by price_per_sqm descending.
     """
     df = matched.copy()
-    df["postcode_district"] = df["postcode"].str[:-3].str.strip()
+    col = geography.value
+
+    if geography is Geography.POSTCODE_DISTRICT:
+        df[col] = df["postcode"].str[:-3].str.strip()
+
+    df = df[df[col].notna()].copy()
 
     grouped = (
-        df.groupby("postcode_district")
+        df.groupby(col)
         .agg(
             num_sales=("price", "count"),
             total_price=("price", "sum"),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,11 +2,13 @@
 
 import pathlib
 
+import pandas as pd
 import pytest
 
 from houseprices.pipeline import (
+    Geography,
     aggregate,
-    aggregate_by_postcode_district,
+    aggregate_by_geography,
     join_datasets,
     load_epc,
     match_report,
@@ -198,7 +200,7 @@ def test_join_result_row_count(joined: "pd.DataFrame") -> None:  # type: ignore[
 
 @pytest.fixture
 def aggregated(joined: "pd.DataFrame") -> "pd.DataFrame":  # type: ignore[name-defined]  # noqa: F821
-    return aggregate_by_postcode_district(joined, min_sales=1)
+    return aggregate_by_geography(joined, Geography.POSTCODE_DISTRICT, min_sales=1)
 
 
 def test_aggregate_postcode_district_extraction(
@@ -231,7 +233,7 @@ def test_aggregate_min_sales_filter(
     joined: "pd.DataFrame",  # type: ignore[name-defined]  # noqa: F821
 ) -> None:
     """Districts below min_sales threshold are excluded from the result."""
-    result = aggregate_by_postcode_district(joined, min_sales=2)
+    result = aggregate_by_geography(joined, Geography.POSTCODE_DISTRICT, min_sales=2)
     districts = set(result["postcode_district"])
     assert "SD1" in districts
     assert "SD2" not in districts  # only 1 sale
@@ -320,3 +322,81 @@ def test_match_report_percentages_sum_to_100(
         + float(report["unmatched_pct"])
     )
     assert abs(total_pct - 100.0) < 0.2  # allow rounding tolerance
+
+
+# ---------------------------------------------------------------------------
+# aggregate_by_geography — Geography.LSOA
+#
+# Synthetic fixture: four rows with LSOA21CD, one without (excluded).
+#
+#   SD0000001: price=430000  area=135.0  price_per_sqm=3185
+#   SD0000002: price=150000  area=65.0   price_per_sqm=2308
+#   (row without LSOA21CD excluded)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lsoa_rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {"price": 250_000, "TOTAL_FLOOR_AREA": 80.0, "LSOA21CD": "SD0000001"},
+            {"price": 180_000, "TOTAL_FLOOR_AREA": 55.0, "LSOA21CD": "SD0000001"},
+            {"price": 150_000, "TOTAL_FLOOR_AREA": 65.0, "LSOA21CD": "SD0000002"},
+            {"price": 200_000, "TOTAL_FLOOR_AREA": 60.0, "LSOA21CD": None},
+        ]
+    )
+
+
+@pytest.fixture
+def lsoa_aggregated(lsoa_rows: pd.DataFrame) -> pd.DataFrame:
+    return aggregate_by_geography(lsoa_rows, Geography.LSOA, min_sales=1)
+
+
+def test_lsoa_aggregate_output_column(lsoa_aggregated: pd.DataFrame) -> None:
+    """Geography key column must be named LSOA21CD."""
+    assert "LSOA21CD" in lsoa_aggregated.columns
+
+
+def test_lsoa_aggregate_expected_codes(lsoa_aggregated: pd.DataFrame) -> None:
+    codes = set(lsoa_aggregated["LSOA21CD"])
+    assert codes == {"SD0000001", "SD0000002"}
+
+
+def test_lsoa_aggregate_excludes_rows_without_code(
+    lsoa_aggregated: pd.DataFrame,
+) -> None:
+    """Rows with no LSOA21CD must be silently dropped."""
+    assert len(lsoa_aggregated) == 2
+
+
+def test_lsoa_aggregate_price_per_sqm(lsoa_aggregated: pd.DataFrame) -> None:
+    """SD0000001: (250000+180000) / (80+55) = 430000/135 = 3185."""
+    row = lsoa_aggregated[lsoa_aggregated["LSOA21CD"] == "SD0000001"]
+    assert row.iloc[0]["price_per_sqm"] == 3185
+
+
+def test_lsoa_aggregate_num_sales(lsoa_aggregated: pd.DataFrame) -> None:
+    row = lsoa_aggregated[lsoa_aggregated["LSOA21CD"] == "SD0000001"]
+    assert row.iloc[0]["num_sales"] == 2
+
+
+def test_lsoa_aggregate_min_sales_filter(lsoa_rows: pd.DataFrame) -> None:
+    result = aggregate_by_geography(lsoa_rows, Geography.LSOA, min_sales=2)
+    codes = set(result["LSOA21CD"])
+    assert "SD0000001" in codes
+    assert "SD0000002" not in codes  # only 1 sale
+
+
+def test_lsoa_aggregate_sorted_descending(lsoa_aggregated: pd.DataFrame) -> None:
+    prices = list(lsoa_aggregated["price_per_sqm"])
+    assert prices == sorted(prices, reverse=True)
+
+
+def test_lsoa_aggregate_output_columns(lsoa_aggregated: pd.DataFrame) -> None:
+    assert set(lsoa_aggregated.columns) >= {
+        "LSOA21CD",
+        "num_sales",
+        "price_per_sqm",
+        "total_price",
+        "total_floor_area",
+    }


### PR DESCRIPTION
## Summary

- Adds a `Geography` enum with `POSTCODE_DISTRICT` and `LSOA` members; enum value is the output column name
- Replaces `aggregate_by_postcode_district` with `aggregate_by_geography(matched, geography, min_sales)` that handles any contiguous geography
- For `POSTCODE_DISTRICT`: derives grouping key from `postcode` column (strips inward code)
- For `LSOA` (and future members): expects `geography.value` column already present — populated by the spatial join step
- Rows without a value for the target geography are silently excluded, so the same DataFrame can produce both outputs
- Adding future geographies (MSOA, OA, etc.) requires only a new enum member — no changes to the function body

## Test plan

- [x] 8 new LSOA tests: output column, expected codes, row exclusion, price_per_sqm maths, num_sales, min_sales filter, sort order, output columns
- [x] All existing postcode district tests updated to new API
- [x] 55 tests pass, 100% coverage
- [x] ruff, mypy strict all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)