### PR TITLE
Add Makefile to simplify workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+.DEFAULT_GOAL := help
+
+# ── Setup ──────────────────────────────────────────────────────────────────
+
+.PHONY: install
+install:  ## Install all dependencies (dev + notebook extras)
+	uv sync --all-extras
+
+# ── Data ───────────────────────────────────────────────────────────────────
+
+.PHONY: download
+download:  ## Download and extract all raw data (~25 GB). Requires .env credentials.
+	uv run python src/houseprices/download.py
+
+.PHONY: clean
+clean:  ## Delete cache/ to force a full pipeline re-run
+	rm -rf cache/
+
+# ── Pipeline ───────────────────────────────────────────────────────────────
+
+.PHONY: run
+run:  ## Run the full pipeline (join → spatial → aggregate → output CSVs)
+	uv run python src/houseprices/pipeline.py
+
+# ── Development ────────────────────────────────────────────────────────────
+
+.PHONY: test
+test:  ## Run tests
+	uv run pytest
+
+.PHONY: test-cov
+test-cov:  ## Run tests with coverage report
+	uv run pytest --cov
+
+.PHONY: lint
+lint:  ## Check linting and formatting
+	uv run ruff check .
+	uv run ruff format --check .
+
+.PHONY: fmt
+fmt:  ## Auto-fix lint and formatting issues
+	uv run ruff check . --fix
+	uv run ruff format .
+
+.PHONY: typecheck
+typecheck:  ## Run mypy type checker
+	uv run mypy src/
+
+.PHONY: check
+check: lint typecheck test-cov  ## Full CI check (lint + types + tests with coverage)
+
+# ── Help ───────────────────────────────────────────────────────────────────
+
+.PHONY: help
+help:  ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew install gdal
 ```bash
 git clone https://github.com/huwd/houseprices.git
 cd houseprices
-uv sync
+make install
 ```
 
 ### 3. Set up credentials
@@ -52,55 +52,25 @@ The EPC bulk download requires a free account at [epc.opendatacommunities.org](h
 
 ```bash
 cp .env.example .env
-```
-
-Edit `.env`:
-
-```dotenv
-EPC_EMAIL=your-email@example.com
-EPC_API_KEY=your-epc-api-key
+# edit .env — add EPC_EMAIL and EPC_API_KEY
 ```
 
 Everything else downloads without credentials.
 
 ### 4. Download the data
 
-This takes a while (~25 GB total). Run it in a tmux session so it survives disconnects:
-
 ```bash
 tmux new -s download
+make download
 ```
 
-```bash
-uv run python - << 'EOF'
-import pathlib
-from houseprices.download import (
-    download_ppd,
-    download_epc, extract_epc,
-    download_ubdc, extract_ubdc,
-    download_os_open_uprn, extract_os_open_uprn,
-    download_lsoa_boundaries,
-)
-
-data = pathlib.Path("data")
-download_ppd(data)
-download_epc(data);   extract_epc(data)
-download_ubdc(data);  extract_ubdc(data)
-download_os_open_uprn(data); extract_os_open_uprn(data)
-download_lsoa_boundaries(data)
-EOF
-```
-
-Each download skips files that already exist, so it is safe to re-run if interrupted.
+~25 GB total. Each file is skipped if it already exists, so safe to re-run if interrupted.
 
 ### 5. Run the pipeline
 
 ```bash
 tmux new -s pipeline
-```
-
-```bash
-uv run python src/houseprices/pipeline.py
+make run
 ```
 
 The pipeline prints live progress — a spinner per step, elapsed time, and row counts on completion. First run takes ~20 minutes; subsequent runs use cached Parquet checkpoints and complete in ~2 minutes.
@@ -115,8 +85,7 @@ Output files are written to `output/`:
 To force a full re-run from scratch:
 
 ```bash
-make clean
-uv run python src/houseprices/pipeline.py
+make clean && make run
 ```
 
 ---
@@ -126,8 +95,8 @@ uv run python src/houseprices/pipeline.py
 The notebook at `notebooks/analysis.ipynb` compares the pipeline output against Anna Powell-Smith's reference figures.
 
 ```bash
-uv sync --all-extras   # install notebook dependencies
-uv run jupyter lab     # then open notebooks/analysis.ipynb
+make install                   # includes notebook extras
+uv run jupyter lab             # then open notebooks/analysis.ipynb
 ```
 
 ---
@@ -135,18 +104,12 @@ uv run jupyter lab     # then open notebooks/analysis.ipynb
 ## Development
 
 ```bash
-uv sync --all-extras          # install dev + notebook dependencies
-uv run pytest                 # run tests
-uv run pytest --cov           # tests with coverage
-uv run ruff check .           # lint
-uv run ruff format --check .  # check formatting
-uv run mypy src/              # type checking
-```
-
-Full CI check (mirrors what runs on pull requests):
-
-```bash
-uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest --cov
+make test        # run tests
+make test-cov    # tests with coverage report
+make lint        # ruff check + format check
+make fmt         # auto-fix lint and formatting
+make typecheck   # mypy
+make check       # everything (lint + types + tests) — mirrors CI
 ```
 
 See [`PLAN.md`](PLAN.md) for full methodology and [`data/SOURCES.md`](data/SOURCES.md) for dataset details.

--- a/src/houseprices/download.py
+++ b/src/houseprices/download.py
@@ -299,3 +299,16 @@ def extract_ubdc(data_dir: pathlib.Path) -> pathlib.Path:
 
     src.unlink()
     return dest
+
+
+if __name__ == "__main__":  # pragma: no cover
+    data = pathlib.Path("data")
+    data.mkdir(exist_ok=True)
+    download_ppd(data)
+    download_epc(data)
+    extract_epc(data)
+    download_ubdc(data)
+    extract_ubdc(data)
+    download_os_open_uprn(data)
+    extract_os_open_uprn(data)
+    download_lsoa_boundaries(data)


### PR DESCRIPTION
## Summary

- Adds a `Makefile` with self-documenting targets (`make help` lists them all)
- Adds `__main__` to `download.py` so `make download` runs the full download + extract sequence in one command
- Updates README so the entire workflow is three commands after cloning:
  ```
  make install
  make download   # after editing .env
  make run
  ```

## Targets

| Target | Purpose |
|---|---|
| `make install` | `uv sync --all-extras` |
| `make download` | all downloads + extracts (~25 GB) |
| `make run` | run the pipeline |
| `make clean` | wipe `cache/` for a full re-run |
| `make test` | pytest |
| `make test-cov` | pytest with coverage |
| `make lint` | ruff check + format check |
| `make fmt` | auto-fix lint and formatting |
| `make typecheck` | mypy |
| `make check` | full CI check (lint + types + tests) |

Also fixes the `make clean` reference that existed in the old README before any Makefile was present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)