### PR TITLE
fix(pipeline): skip malformed PPD rows with unterminated quotes

### DIFF
--- a/src/houseprices/pipeline.py
+++ b/src/houseprices/pipeline.py
@@ -160,7 +160,7 @@ def join_datasets(
         ),
         -- PPD: category A only (HMLR full download has no header row)
         ppd AS (
-            SELECT * FROM read_csv('{ppd}', header=false, names=[
+            SELECT * FROM read_csv('{ppd}', header=false, ignore_errors=true, names=[
                 'transaction_unique_identifier', 'price', 'date_of_transfer',
                 'postcode', 'property_type', 'new_build_flag', 'tenure_type',
                 'paon', 'saon', 'street', 'locality', 'town_city',


### PR DESCRIPTION
The HMLR `pp-complete.csv` contains a small number of rows where address fields include unescaped double-quotes (e.g. line 2,460,653). DuckDB's strict CSV parser raises `InvalidInputException` on these.

Adding `ignore_errors=true` to the `read_csv` call matches the behaviour of `pd.read_csv(on_bad_lines="warn")` that was in place before the DuckDB migration — bad rows are silently skipped.

Fixes the error seen on first full pipeline run against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)