### PR TITLE
feat(make): add clean-data target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,16 @@ install:  ## Install all dependencies (dev + notebook extras)
 download:  ## Download and extract all raw data (~25 GB). Requires .env credentials.
 	uv run python src/houseprices/download.py
 
+.PHONY: clean-data
+clean-data:  ## Remove downloaded data files from data/ (preserves committed files and dotfiles)
+	find data/ -maxdepth 1 -type f ! -name '.*' ! -name 'SOURCES.md' ! -name 'anna_reference.json.example' -delete
+
 .PHONY: clean-cache
 clean-cache:  ## Delete pipeline checkpoints (keeps slim Parquets; safe to re-run without re-downloading)
 	rm -f cache/matched.parquet cache/uprn_lsoa.parquet
 
 .PHONY: dump-cache
-dump-cache:  ## Delete all cache/ contents including slim Parquets (requires re-download to re-run)
+dump-cache:  ## Delete all cache/ contents and slim Parquets (pair with clean-data + download for full reset)
 	find cache/ -maxdepth 1 -type f ! -name '.*' -delete
 
 # ── Pipeline ───────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ To re-run the join and spatial steps without re-downloading:
 make clean-cache && make run
 ```
 
-To force a complete reset (deletes slim Parquets — requires re-download):
+To force a complete reset (wipes all cache and data, then re-downloads):
 
 ```bash
-make dump-cache && make download && make run
+make dump-cache && make clean-data && make download && make run
 ```
 
 ---
@@ -118,6 +118,7 @@ make typecheck   # mypy
 make check       # everything (lint + types + tests) — mirrors CI
 make clean-cache # delete pipeline checkpoints (keeps slim Parquets)
 make dump-cache  # delete all cache contents (requires re-download to re-run)
+make clean-data  # remove downloaded data files (preserves committed files)
 ```
 
 See [`PLAN.md`](PLAN.md) for full methodology and [`data/SOURCES.md`](data/SOURCES.md) for dataset details.
@@ -159,7 +160,8 @@ The pipeline manages disk space aggressively to stay viable on modest machines.
 ### `make clean` vs `make clean-all`
 
 - `make clean-cache` — deletes `matched.parquet` and `uprn_lsoa.parquet` only. Slim Parquets are preserved, so re-running does not require re-downloading the raw data.
-- `make dump-cache` — deletes all files in `cache/` including slim Parquets. A subsequent `make run` will fail unless you run `make download` first to re-fetch the raw data.
+- `make dump-cache` — deletes all files in `cache/` including slim Parquets. Pair with `make clean-data` and `make download` for a full reset.
+- `make clean-data` — removes all downloaded files from `data/`, preserving committed files (`SOURCES.md`, `anna_reference.json.example`) and dotfiles (`.gitkeep`).
 
 ### RAM
 


### PR DESCRIPTION
## Summary

- Adds `make clean-data` — removes all downloaded files from `data/` while preserving committed files (`SOURCES.md`, `anna_reference.json.example`) and dotfiles (`.gitkeep`)
- Updates `dump-cache` description to signpost the full reset workflow
- Documents `clean-data` in the README System resources section and Development commands

## Full reset workflow

```bash
make dump-cache && make clean-data && make download && make run
```

## Implementation

Uses the same `find` pattern as `dump-cache`:

```makefile
find data/ -maxdepth 1 -type f ! -name '.*' ! -name 'SOURCES.md' ! -name 'anna_reference.json.example' -delete
```

The exclusion list mirrors the `.gitignore` carve-outs for `data/*`, so committed files are never deleted.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)