### PR TITLE
fix: load .env in pipeline so DuckDB limits apply

### DIFF
--- a/src/houseprices/pipeline.py
+++ b/src/houseprices/pipeline.py
@@ -9,9 +9,12 @@ from enum import Enum
 
 import duckdb
 import pandas as pd
+from dotenv import load_dotenv
 from rich.console import Console
 
 from houseprices.spatial import build_uprn_lsoa
+
+load_dotenv()
 
 # ---------------------------------------------------------------------------
 # Default paths (relative to project root)


### PR DESCRIPTION
## Summary

- `pipeline.py` was not calling `load_dotenv()`, so `DUCKDB_MEMORY_LIMIT` and `DUCKDB_THREADS` set in `.env` were silently ignored on `make run`
- Only `download.py` was loading the dotenv file
- Adds `load_dotenv()` call to `pipeline.py` to match

## Test plan

- [ ] Run `make run` and confirm the DuckDB config line shows the expected limits rather than `memory_limit=unlimited  threads=all`
- CI passes (lint, types, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)