### PR TITLE
chore: raise default MEM_MAX to 7G

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dump-cache:  ## Delete all cache/ contents and slim Parquets (pair with clean-da
 # Prevents oomd killing the whole terminal session if the pipeline spikes.
 # Must sit above DUCKDB_MEMORY_LIMIT + Python overhead (~2 GB), but below
 # available RAM. Adjust downward on machines with less than 8 GB free.
-MEM_MAX ?= 5G
+MEM_MAX ?= 7G
 
 .PHONY: run
 run:  ## Run the full pipeline with a hard memory cap (join → spatial → aggregate → output CSVs)


### PR DESCRIPTION
## Summary

- Raises `MEM_MAX` default in the Makefile from `5G` to `7G`
- The previous value was set conservatively when `DUCKDB_MEMORY_LIMIT` was 3 GB; now that the recommended `.env` value is 5 GB, the cgroup ceiling needs to match
- `.env` changes (DUCKDB_MEMORY_LIMIT, DUCKDB_THREADS) are local-only and not committed — see `.env.example` for guidance

## Test plan

- [ ] `make run` starts without the systemd cgroup immediately killing the process
- [ ] Lower-RAM machines can still override: `make run MEM_MAX=5G`

🤖 Generated with [Claude Code](https://claude.com/claude-code)