### PR TITLE
chore: lower MEM_MAX to 5G

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dump-cache:  ## Delete all cache/ contents and slim Parquets (pair with clean-da
 # Prevents oomd killing the whole terminal session if the pipeline spikes.
 # Must sit above DUCKDB_MEMORY_LIMIT + Python overhead (~2 GB), but below
 # available RAM. Adjust downward on machines with less than 8 GB free.
-MEM_MAX ?= 7G
+MEM_MAX ?= 5G
 
 .PHONY: run
 run:  ## Run the full pipeline with a hard memory cap (join → spatial → aggregate → output CSVs)


### PR DESCRIPTION
## Summary

- Lowers `MEM_MAX` from `7G` to `5G` in the Makefile
- On this 7.7 GB laptop the old default allowed the pipeline to consume nearly all available RAM
- On 15 Mar 2026 this caused a hard OS crash — the kernel scheduler became unresponsive under combined thermal and memory pressure, with no OOM kill logged
- The matching `.env` change (`DUCKDB_MEMORY_LIMIT` 5GB → 3GB) is gitignored; `.env.example` already documented 3GB as correct for an 8 GB machine

## Memory budget at new limits

| Layer | Allocation |
|---|---|
| DuckDB (`DUCKDB_MEMORY_LIMIT`) | 3 GB |
| Python / pyarrow overhead | ~2 GB |
| **Pipeline cgroup ceiling (`MEM_MAX`)** | **5 GB** |
| Reserved for OS + desktop | ~2.7 GB |

## Test plan

- [ ] Run `make run` and confirm pipeline completes without OOM or system freeze
- [ ] Confirm cgroup ceiling fires correctly if DuckDB exceeds 3 GB (check `systemd-run` scope via `systemctl --user status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)