### PR TITLE
fix: join_datasets writes directly to Parquet to avoid OOM

### DIFF
--- a/src/houseprices/pipeline.py
+++ b/src/houseprices/pipeline.py
@@ -420,21 +420,26 @@ def join_datasets(
     ppd_path: str | pathlib.Path,
     epc_path: str | pathlib.Path,
     ubdc_path: str | pathlib.Path,
+    dst: pathlib.Path,
     *,
     on_tier1_complete: Callable[[pd.DataFrame], None] | None = None,
-) -> pd.DataFrame:
-    """Join PPD to EPC using a tiered strategy.
+) -> None:
+    """Join PPD to EPC using a tiered strategy, writing result to *dst*.
 
     Tier 1 — exact UPRN join via the UBDC lookup table.
     Tier 2 — address normalisation fallback for records without a UPRN match.
 
-    Returns a DataFrame of matched records with a `match_tier` column (1 or 2).
-    PPD records with ppd_category_type != 'A' are excluded before joining.
-    Unmatched PPD records are not included in the result.
+    Writes a Parquet file to *dst* containing matched records with a
+    `match_tier` column (1 or 2).  PPD records with ppd_category_type != 'A'
+    are excluded before joining.  Unmatched PPD records are not included.
+
+    The final combine step uses DuckDB COPY to stream directly to disk,
+    avoiding materialising the full result into Python heap memory.
 
     If *on_tier1_complete* is provided it is called with the tier-1 DataFrame
     before tier-2 begins, allowing callers to report intermediate progress.
     """
+    dst.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory() as _tmp:
         tmp = pathlib.Path(_tmp)
         tier1_path = tmp / "tier1.parquet"
@@ -452,11 +457,13 @@ def join_datasets(
         del tier2
         gc.collect()
 
-        return duckdb.execute(f"""
-            SELECT * FROM read_parquet('{tier1_path}')
-            UNION ALL
-            SELECT * FROM read_parquet('{tier2_path}')
-        """).df()
+        duckdb.execute(f"""
+            COPY (
+                SELECT * FROM read_parquet('{tier1_path}')
+                UNION ALL
+                SELECT * FROM read_parquet('{tier2_path}')
+            ) TO '{dst}' (FORMAT PARQUET, COMPRESSION ZSTD)
+        """)
 
 
 def match_report(matched: pd.DataFrame, total_ppd: int) -> dict[str, int | float]:
@@ -666,12 +673,29 @@ def run(
     def _on_tier1(df: pd.DataFrame) -> None:
         console.print(f"      [dim]tier 1: {len(df):,} UPRN matches[/dim]")
 
-    matched = step(
-        "matched",
-        lambda: join_datasets(
-            ppd_path, epc_path, ubdc_path, on_tier1_complete=_on_tier1
-        ),
-    )
+    matched_parquet = cache_dir / "matched.parquet"
+    if matched_parquet.exists():
+        console.print(f"  [dim]⊘  {'matched':<18} skipped (cached)[/dim]")
+    else:
+        t0 = time.monotonic()
+        with console.status("  [yellow]⏳  matched…[/yellow]"):
+            join_datasets(
+                ppd_path,
+                epc_path,
+                ubdc_path,
+                dst=matched_parquet,
+                on_tier1_complete=_on_tier1,
+            )
+        elapsed = _fmt_elapsed(time.monotonic() - t0)
+        n_rows = duckdb.execute(
+            f"SELECT COUNT(*) FROM read_parquet('{matched_parquet}')"
+        ).fetchone()[0]  # type: ignore[index]
+        rss = _rss_mb()
+        console.print(
+            f"  [green]✓[/green]  {'matched':<18} {elapsed:<8} {n_rows:>14,} rows"
+            f"  [dim]RSS {rss} MB[/dim]"
+        )
+    matched = pd.read_parquet(matched_parquet)
     matched_uprns = set(matched["uprn"].dropna().astype(int))
     uprn_lsoa = step(
         "uprn_lsoa",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -145,14 +145,15 @@ def test_load_epc_total_row_count() -> None:
 
 
 @pytest.fixture
-def joined(epc_slim: pathlib.Path) -> "pd.DataFrame":  # type: ignore[name-defined]  # noqa: F821
-    import pandas as pd  # noqa: F401
-
-    return join_datasets(
+def joined(epc_slim: pathlib.Path, tmp_path: pathlib.Path) -> pd.DataFrame:
+    dst = tmp_path / "matched.parquet"
+    join_datasets(
         FIXTURES / "ppd_sample.csv",
         epc_slim,
         FIXTURES / "ubdc_sample.csv",
+        dst=dst,
     )
+    return pd.read_parquet(dst)
 
 
 TXN_001 = "{A0000001-0000-0000-0000-000000000000}"
@@ -613,9 +614,11 @@ def test_join_datasets_accepts_prepared_parquet(tmp_path: pathlib.Path) -> None:
     """join_datasets must produce the same result when fed Parquet-prepared inputs."""
     epc_slim = tmp_path / "epc_slim.parquet"
     ubdc_slim = tmp_path / "ubdc_slim.parquet"
+    dst = tmp_path / "matched.parquet"
     prepare_epc(FIXTURES / "epc_sample.csv", epc_slim)
     prepare_ubdc(FIXTURES / "ubdc_sample.csv", ubdc_slim)
-    result = join_datasets(FIXTURES / "ppd_sample.csv", epc_slim, ubdc_slim)
+    join_datasets(FIXTURES / "ppd_sample.csv", epc_slim, ubdc_slim, dst=dst)
+    result = pd.read_parquet(dst)
     assert len(result) == 4
     assert set(result["match_tier"]) == {1, 2}
 
@@ -700,12 +703,14 @@ def test_join_tier2_postcode_filter_excludes_nonmatching_epc(
 
 
 def test_join_datasets_result_has_no_duplicate_transactions(
-    epc_slim: pathlib.Path,
+    epc_slim: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
     """Combining tier1 and tier2 must not produce duplicate transaction IDs."""
-    result = join_datasets(
-        FIXTURES / "ppd_sample.csv", epc_slim, FIXTURES / "ubdc_sample.csv"
+    dst = tmp_path / "matched.parquet"
+    join_datasets(
+        FIXTURES / "ppd_sample.csv", epc_slim, FIXTURES / "ubdc_sample.csv", dst=dst
     )
+    result = pd.read_parquet(dst)
     assert result["transaction_unique_identifier"].nunique() == len(result)
 
 
@@ -726,7 +731,7 @@ def test_join_tier2_accepts_parquet_path_for_tier1(
 
 
 def test_join_datasets_calls_callback_with_tier1_dataframe(
-    epc_slim: pathlib.Path,
+    epc_slim: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
     """on_tier1_complete is called once with the tier 1 DataFrame before tier 2 runs."""
     calls: list[pd.DataFrame] = []
@@ -734,20 +739,26 @@ def test_join_datasets_calls_callback_with_tier1_dataframe(
         FIXTURES / "ppd_sample.csv",
         epc_slim,
         FIXTURES / "ubdc_sample.csv",
+        dst=tmp_path / "matched.parquet",
         on_tier1_complete=calls.append,
     )
     assert len(calls) == 1
     assert (calls[0]["match_tier"] == 1).all()
 
 
-def test_join_datasets_no_callback_does_not_raise(epc_slim: pathlib.Path) -> None:
-    """join_datasets without on_tier1_complete runs normally."""
-    result = join_datasets(
+def test_join_datasets_no_callback_does_not_raise(
+    epc_slim: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """join_datasets without on_tier1_complete writes result to dst."""
+    dst = tmp_path / "matched.parquet"
+    join_datasets(
         FIXTURES / "ppd_sample.csv",
         epc_slim,
         FIXTURES / "ubdc_sample.csv",
+        dst=dst,
     )
-    assert len(result) == 4
+    assert dst.exists()
+    assert len(pd.read_parquet(dst)) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -812,12 +823,10 @@ def test_join_datasets_accepts_prepared_ppd_parquet(
 ) -> None:
     """join_datasets must produce the same result when fed a slim PPD Parquet."""
     ppd_slim = tmp_path / "ppd_slim.parquet"
+    dst = tmp_path / "matched.parquet"
     prepare_ppd(FIXTURES / "ppd_sample.csv", ppd_slim)
-    result = join_datasets(
-        ppd_slim,
-        epc_slim,
-        FIXTURES / "ubdc_sample.csv",
-    )
+    join_datasets(ppd_slim, epc_slim, FIXTURES / "ubdc_sample.csv", dst=dst)
+    result = pd.read_parquet(dst)
     assert len(result) == 4
     assert set(result["match_tier"]) == {1, 2}
 


### PR DESCRIPTION
## Summary

- Changes `join_datasets` to write its output directly to a Parquet file via DuckDB `COPY` instead of returning a `pd.DataFrame`
- Adds a required `dst: pathlib.Path` parameter to control the output path
- Updates the `run()` pipeline function to read the Parquet back after writing, and to skip the step if a cached file already exists
- Updates all tests to pass `dst` and read back from Parquet

## Why

The previous implementation materialised the full join result into Python heap memory before returning it. On large datasets this caused OOM kills. Streaming directly to disk with `COPY … TO … (FORMAT PARQUET)` keeps peak RSS low regardless of result size.

## Test plan

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check .` passes
- [ ] `uv run mypy src/` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)