### PR TITLE
feat: add make explore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ run:  ## Run the full pipeline with a hard memory cap (join → spatial → aggr
 		env DUCKDB_MEMORY_LIMIT=$(DUCKDB_MEMORY_LIMIT) \
 		uv run python src/houseprices/pipeline.py
 
+# ── Notebook ───────────────────────────────────────────────────────────────
+
+.PHONY: explore
+explore:  ## Open the analysis notebook in Jupyter Lab
+	uv run jupyter lab notebooks/analysis.ipynb
+
 # ── Development ────────────────────────────────────────────────────────────
 
 .PHONY: test


### PR DESCRIPTION
## Summary

- Adds `make explore` target that opens `notebooks/analysis.ipynb` in Jupyter Lab

## Test plan

- [ ] `make explore` launches Jupyter Lab with the analysis notebook open
- [ ] `make help` shows the new target

🤖 Generated with [Claude Code](https://claude.com/claude-code)