### PR TITLE
fix: correct EPC certificate selection description in methodology

### DIFF
--- a/output/index.html
+++ b/output/index.html
@@ -101,15 +101,19 @@
       <a href="https://www.gov.uk/government/collections/price-paid-data">HM Land Registry's
         Price Paid dataset</a> (standard residential sales to individuals, Jan 1995–Mar 2026).
       Floor area per property is taken from
-      <a href="https://epc.opendatacommunities.org/">Energy Performance Certificates</a>,
-      using the most recent certificate lodged for each property.
+      <a href="https://epc.opendatacommunities.org/">Energy Performance Certificates</a>.
     </p>
     <p>Each sale is matched to its EPC in two stages. First, an exact match on
       the property's Unique Property Reference Number (UPRN) using the
       <a href="https://doi.org/10.20394/agu7hprj">UBDC Price Paid–UPRN lookup table</a>,
-      which covers transactions up to January 2022. For sales after that date — where
-      no UPRN link is available — a second stage matches on postcode plus a normalised
-      address string (combining sub-address, building name or number, and street name).
+      which covers transactions up to January 2022. For each matched sale, the
+      certificate closest in time is used — preferring the most recent one lodged
+      before the sale date, with a fallback to the earliest post-sale certificate
+      if none exists within a ten-year window.
+      For sales after January 2022 — where no UPRN link is available — a second
+      stage matches on postcode plus a normalised address string (combining
+      sub-address, building name or number, and street name), and the most recent
+      certificate for that address is used.
     </p>
     <p>The price per m² for each postcode district is the total transaction value of all
       matched sales divided by their total floor area — not a mean of per-property ratios.

--- a/scripts/page_template.html
+++ b/scripts/page_template.html
@@ -101,15 +101,19 @@
       <a href="https://www.gov.uk/government/collections/price-paid-data">HM Land Registry's
         Price Paid dataset</a> (standard residential sales to individuals, Jan 1995–__DATA_DATE__).
       Floor area per property is taken from
-      <a href="https://epc.opendatacommunities.org/">Energy Performance Certificates</a>,
-      using the most recent certificate lodged for each property.
+      <a href="https://epc.opendatacommunities.org/">Energy Performance Certificates</a>.
     </p>
     <p>Each sale is matched to its EPC in two stages. First, an exact match on
       the property's Unique Property Reference Number (UPRN) using the
       <a href="https://doi.org/10.20394/agu7hprj">UBDC Price Paid–UPRN lookup table</a>,
-      which covers transactions up to January 2022. For sales after that date — where
-      no UPRN link is available — a second stage matches on postcode plus a normalised
-      address string (combining sub-address, building name or number, and street name).
+      which covers transactions up to January 2022. For each matched sale, the
+      certificate closest in time is used — preferring the most recent one lodged
+      before the sale date, with a fallback to the earliest post-sale certificate
+      if none exists within a ten-year window.
+      For sales after January 2022 — where no UPRN link is available — a second
+      stage matches on postcode plus a normalised address string (combining
+      sub-address, building name or number, and street name), and the most recent
+      certificate for that address is used.
     </p>
     <p>The price per m² for each postcode district is the total transaction value of all
       matched sales divided by their total floor area — not a mean of per-property ratios.


### PR DESCRIPTION
## Summary

- Removes the inaccurate claim that "the most recent certificate lodged for each property" is used — this was only true for Tier 2 (address-matched sales)
- Tier 1 (UPRN-matched, pre-2022 sales) actually performs temporal selection: closest certificate to the sale date, preferring pre-sale, falling back to earliest post-sale within 10 years
- Describes each tier's EPC selection logic separately so the methodology text matches the pipeline

## Preview

https://feat-page-updates.houseprices-6r0.pages.dev/