### PR TITLE
fix: make district count dynamic in page output

### DIFF
--- a/output/index.html
+++ b/output/index.html
@@ -31,7 +31,7 @@
       I've re-run the analysis with data to Mar 2026, matching records between the Price Paid dataset and floor
       area
       from the Energy Performance Certificate dataset.
-      The result is a national dataset of price per m² for 2,800 postcode districts.
+      The result is a national dataset of price per m² for 2,277 postcode districts.
     </p>
     <p id="price-range-text" class="intro-text"></p>
   </div>
@@ -122,7 +122,7 @@
       or parts of the City of London.
     </p>
     <p>The map uses a hybrid colour scale. The first seven colour bands use quantile breaks,
-      dividing the 2,277 districts into roughly equal groups of ~325 each — this maximises
+      dividing the 2,277 districts into roughly equal groups — this maximises
       visual contrast across the bulk of the distribution. The top two bands use fixed
       thresholds: £5,000/m² and £10,000/m². Districts above £5,000/m² are predominantly
       inner London; above £10,000/m² is almost exclusively central London (Mayfair,

--- a/scripts/build_page.py
+++ b/scripts/build_page.py
@@ -373,6 +373,7 @@ def main() -> None:
         template.replace("__STATS__", json.dumps(stats, separators=(",", ":")))
         .replace("__VERSION__", version)
         .replace("__DATA_DATE__", data_date)
+        .replace("__NUM_DISTRICTS__", f"{stats['num_districts']:,}")
         .replace("__CHANGELOG_HTML__", changelog_html)
     )
 

--- a/scripts/page_template.html
+++ b/scripts/page_template.html
@@ -31,7 +31,7 @@
       I've re-run the analysis with data to __DATA_DATE__, matching records between the Price Paid dataset and floor
       area
       from the Energy Performance Certificate dataset.
-      The result is a national dataset of price per m² for 2,800 postcode districts.
+      The result is a national dataset of price per m² for __NUM_DISTRICTS__ postcode districts.
     </p>
     <p id="price-range-text" class="intro-text"></p>
   </div>
@@ -122,7 +122,7 @@
       or parts of the City of London.
     </p>
     <p>The map uses a hybrid colour scale. The first seven colour bands use quantile breaks,
-      dividing the 2,277 districts into roughly equal groups of ~325 each — this maximises
+      dividing the __NUM_DISTRICTS__ districts into roughly equal groups — this maximises
       visual contrast across the bulk of the distribution. The top two bands use fixed
       thresholds: £5,000/m² and £10,000/m². Districts above £5,000/m² are predominantly
       inner London; above £10,000/m² is almost exclusively central London (Mayfair,


### PR DESCRIPTION
## Summary

- Intro text hardcoded "2,800 postcode districts" which was stale — actual figure is 2,277
- Adds `__NUM_DISTRICTS__` placeholder to `page_template.html`, substituted by `build_page.py` from the real CSV row count so it stays accurate after each data refresh
- Also removes the derived "~325 each" figure from the colour scale description, which would go stale in the same way

## Preview

https://fix-dynamic-district-count.houseprices-6r0.pages.dev/