### PR TITLE
chore: add Protect main branch ruleset

### DIFF
--- a/.github/rulesets/protect_main.json
+++ b/.github/rulesets/protect_main.json
@@ -1,0 +1,49 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "dismiss_stale_reviews_on_push": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "lint"
+          },
+          {
+            "context": "typecheck"
+          },
+          {
+            "context": "test"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
## Summary

- Commits the `protect_main` ruleset JSON to `.github/rulesets/`
- Ruleset already imported live (id `14198348`) — this PR just tracks it in source control

## What the ruleset enforces

- No direct pushes to `main` — all changes must go via PR
- No force-push, no branch deletion
- Required status checks: `lint`, `typecheck`, `test` must pass before merge

Note: `commit_message_pattern` (conventional commits regex) is a GitHub Enterprise feature and is not available on this plan.

## Preview

https://chore-add-main-branch-protection.houseprices-6r0.pages.dev/